### PR TITLE
Mavlab course2019 fix opencv

### DIFF
--- a/conf/airframes/tudelft/bebop_course2019_orangeavoid.xml
+++ b/conf/airframes/tudelft/bebop_course2019_orangeavoid.xml
@@ -74,6 +74,9 @@
       <define name="VIDEO_CAPTURE_CAMERA" value="front_camera"/>
       <define name="VIDEO_CAPTURE_FPS" value="10"/>
     </module>
+    <!--<module name="cv_opencvdemo">
+      <define name="OPENCVDEMO_CAMERA" value="front_camera"/>
+    </module>-->
     <module name="cv_detect_color_object">
       <define name="COLOR_OBJECT_DETECTOR_CAMERA1" value="front_camera"/>
       <define name="COLOR_OBJECT_DETECTOR_FPS1" value="0"/>

--- a/conf/airframes/tudelft/bebop_course2019_orangeavoid.xml
+++ b/conf/airframes/tudelft/bebop_course2019_orangeavoid.xml
@@ -74,9 +74,9 @@
       <define name="VIDEO_CAPTURE_CAMERA" value="front_camera"/>
       <define name="VIDEO_CAPTURE_FPS" value="10"/>
     </module>
-    <!--<module name="cv_opencvdemo">
+    <module name="cv_opencvdemo">
       <define name="OPENCVDEMO_CAMERA" value="front_camera"/>
-    </module>-->
+    </module>
     <module name="cv_detect_color_object">
       <define name="COLOR_OBJECT_DETECTOR_CAMERA1" value="front_camera"/>
       <define name="COLOR_OBJECT_DETECTOR_FPS1" value="0"/>

--- a/conf/airframes/tudelft/bebop_course2019_orangeavoid.xml
+++ b/conf/airframes/tudelft/bebop_course2019_orangeavoid.xml
@@ -74,9 +74,6 @@
       <define name="VIDEO_CAPTURE_CAMERA" value="front_camera"/>
       <define name="VIDEO_CAPTURE_FPS" value="10"/>
     </module>
-    <module name="cv_opencvdemo">
-      <define name="OPENCVDEMO_CAMERA" value="front_camera"/>
-    </module>
     <module name="cv_detect_color_object">
       <define name="COLOR_OBJECT_DETECTOR_CAMERA1" value="front_camera"/>
       <define name="COLOR_OBJECT_DETECTOR_FPS1" value="0"/>

--- a/conf/modules/cv_opencvdemo.xml
+++ b/conf/modules/cv_opencvdemo.xml
@@ -19,11 +19,11 @@
     <file name="cv_opencvdemo.c"/>
     <file name="opencv_example.cpp"/>
     <file name="opencv_image_functions.cpp"/>
-    <flag name="CXXFLAGS" value="I$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install/include"/>
+    <flag name="CXXFLAGS" value="I$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_arm/include"/>
     
-	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install/lib" />
+	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_arm/lib" />
 	<flag name="LDFLAGS" value="lopencv_world" />
-	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install/share/OpenCV/3rdparty/lib" />
+	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_arm/share/OpenCV/3rdparty/lib" />
 	<flag name="LDFLAGS" value="llibprotobuf" />
 	<flag name="LDFLAGS" value="llibjpeg-turbo" />
 	<flag name="LDFLAGS" value="llibpng" />
@@ -47,25 +47,10 @@
     <flag name="LDFLAGS" value="lopencv_world" />
     <flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_pc/share/OpenCV/3rdparty/lib" />
     <flag name="LDFLAGS" value="lprotobuf" />
-    <flag name="LDFLAGS" value="littnotify"/>
-    <flag name="LDFLAGS" value="lquirc"/>
-    <flag name="LDFLAGS" value="lippiw"/>
-    <flag name="LDFLAGS" value="lippicv"/>
     <flag name="LDFLAGS" value="ljpeg"/>
+    <flag name="LDFLAGS" value="lpng"/>
     <flag name="LDFLAGS" value="ltiff"/>
     <flag name="LDFLAGS" value="ldc1394"/>
-    <flag name="LDFLAGS" value="lgtk-3"/>
-    <flag name="LDFLAGS" value="lgdk-3"/>
-    <flag name="LDFLAGS" value="lpangocairo-1.0"/>
-    <flag name="LDFLAGS" value="lpango-1.0"/>
-    <flag name="LDFLAGS" value="latk-1.0"/>
-    <flag name="LDFLAGS" value="lcairo-gobject"/>
-    <flag name="LDFLAGS" value="lcairo"/>
-    <flag name="LDFLAGS" value="lgdk_pixbuf-2.0"/>
-    <flag name="LDFLAGS" value="lgio-2.0"/>
-    <flag name="LDFLAGS" value="lgobject-2.0"/>
-    <flag name="LDFLAGS" value="lglib-2.0"/>
-    <flag name="LDFLAGS" value="lgthread-2.0"/>
     <flag name="LDFLAGS" value="lz"/>
     <flag name="LDFLAGS" value="ldl"/>
     <flag name="LDFLAGS" value="lm"/>

--- a/conf/modules/cv_opencvdemo.xml
+++ b/conf/modules/cv_opencvdemo.xml
@@ -20,20 +20,22 @@
     <file name="opencv_example.cpp"/>
     <file name="opencv_image_functions.cpp"/>
     <flag name="CXXFLAGS" value="I$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install/include"/>
-
+    
 	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install/lib" />
 	<flag name="LDFLAGS" value="lopencv_world" />
 	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install/share/OpenCV/3rdparty/lib" />
-	<flag name="LDFLAGS" value="ltegra_hal" />
-	<flag name="LDFLAGS" value="lzlib" />
+	<flag name="LDFLAGS" value="llibprotobuf" />
 	<flag name="LDFLAGS" value="llibjpeg" />
 	<flag name="LDFLAGS" value="llibpng" />
 	<flag name="LDFLAGS" value="llibtiff" />
-	<flag name="LDFLAGS" value="lstdc++" />
+	<flag name="LDFLAGS" value="lzlib" />
+	<flag name="LDFLAGS" value="ltegra_hal" />
 	<flag name="LDFLAGS" value="ldl" />
 	<flag name="LDFLAGS" value="lm" />
 	<flag name="LDFLAGS" value="lpthread" />
 	<flag name="LDFLAGS" value="lrt" />
+    
+    <!-- <flag name="LDFLAGS" value="Wl,--verbose"/> -->
 
   </makefile>
   <makefile target="nps">

--- a/conf/modules/cv_opencvdemo.xml
+++ b/conf/modules/cv_opencvdemo.xml
@@ -35,10 +35,6 @@
 	<flag name="LDFLAGS" value="lm" />
 	<flag name="LDFLAGS" value="lpthread" />
 	<flag name="LDFLAGS" value="lrt" />
-
-    
-    <!-- <flag name="LDFLAGS" value="Wl,--verbose"/> -->
-
   </makefile>
   <makefile target="nps">
     <file name="cv_opencvdemo.c"/>
@@ -53,15 +49,27 @@
     <flag name="LDFLAGS" value="lprotobuf" />
     <flag name="LDFLAGS" value="littnotify"/>
     <flag name="LDFLAGS" value="lquirc"/>
+    <flag name="LDFLAGS" value="lippiw"/>
+    <flag name="LDFLAGS" value="lippicv"/>
+    <flag name="LDFLAGS" value="ljpeg"/>
+    <flag name="LDFLAGS" value="ltiff"/>
+    <flag name="LDFLAGS" value="ldc1394"/>
+    <flag name="LDFLAGS" value="lgtk-3"/>
+    <flag name="LDFLAGS" value="lgdk-3"/>
+    <flag name="LDFLAGS" value="lpangocairo-1.0"/>
+    <flag name="LDFLAGS" value="lpango-1.0"/>
+    <flag name="LDFLAGS" value="latk-1.0"/>
+    <flag name="LDFLAGS" value="lcairo-gobject"/>
+    <flag name="LDFLAGS" value="lcairo"/>
+    <flag name="LDFLAGS" value="lgdk_pixbuf-2.0"/>
+    <flag name="LDFLAGS" value="lgio-2.0"/>
+    <flag name="LDFLAGS" value="lgobject-2.0"/>
+    <flag name="LDFLAGS" value="lglib-2.0"/>
+    <flag name="LDFLAGS" value="lgthread-2.0"/>
     <flag name="LDFLAGS" value="lz"/>
     <flag name="LDFLAGS" value="ldl"/>
     <flag name="LDFLAGS" value="lm"/>
     <flag name="LDFLAGS" value="lpthread"/>
     <flag name="LDFLAGS" value="lrt"/>
-    
-    <!-- <raw>
-      nps.CXXFLAGS += $(shell pkg-config opencv --cflags)
-      nps.LDFLAGS  += -lopencv_imgproc -lopencv_highgui -lopencv_core
-    </raw> -->
   </makefile>
 </module>

--- a/conf/modules/cv_opencvdemo.xml
+++ b/conf/modules/cv_opencvdemo.xml
@@ -25,15 +25,17 @@
 	<flag name="LDFLAGS" value="lopencv_world" />
 	<flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install/share/OpenCV/3rdparty/lib" />
 	<flag name="LDFLAGS" value="llibprotobuf" />
-	<flag name="LDFLAGS" value="llibjpeg" />
+	<flag name="LDFLAGS" value="llibjpeg-turbo" />
 	<flag name="LDFLAGS" value="llibpng" />
 	<flag name="LDFLAGS" value="llibtiff" />
 	<flag name="LDFLAGS" value="lzlib" />
 	<flag name="LDFLAGS" value="ltegra_hal" />
+	<flag name="LDFLAGS" value="lquirc" />
 	<flag name="LDFLAGS" value="ldl" />
 	<flag name="LDFLAGS" value="lm" />
 	<flag name="LDFLAGS" value="lpthread" />
 	<flag name="LDFLAGS" value="lrt" />
+
     
     <!-- <flag name="LDFLAGS" value="Wl,--verbose"/> -->
 
@@ -42,9 +44,24 @@
     <file name="cv_opencvdemo.c"/>
     <file name="opencv_example.cpp"/>
     <file name="opencv_image_functions.cpp"/>
-    <raw>
+    
+    <flag name="CXXFLAGS" value="I$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/include"/>
+    
+    <flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_pc/lib" />
+    <flag name="LDFLAGS" value="lopencv_world" />
+    <flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_pc/share/OpenCV/3rdparty/lib" />
+    <flag name="LDFLAGS" value="lprotobuf" />
+    <flag name="LDFLAGS" value="littnotify"/>
+    <flag name="LDFLAGS" value="lquirc"/>
+    <flag name="LDFLAGS" value="lz"/>
+    <flag name="LDFLAGS" value="ldl"/>
+    <flag name="LDFLAGS" value="lm"/>
+    <flag name="LDFLAGS" value="lpthread"/>
+    <flag name="LDFLAGS" value="lrt"/>
+    
+    <!-- <raw>
       nps.CXXFLAGS += $(shell pkg-config opencv --cflags)
       nps.LDFLAGS  += -lopencv_imgproc -lopencv_highgui -lopencv_core
-    </raw>
+    </raw> -->
   </makefile>
 </module>

--- a/conf/userconf/tudelft/course2019_conf.xml
+++ b/conf/userconf/tudelft/course2019_conf.xml
@@ -7,7 +7,7 @@
    telemetry="telemetry/default_rotorcraft.xml"
    flight_plan="flight_plans/tudelft/course2019_orangeavoid_cyberzoo.xml"
    settings="settings/rotorcraft_basic.xml"
-   settings_modules="modules/video_rtp_stream.xml modules/orange_avoider.xml modules/cv_detect_color_object.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
+   settings_modules="modules/video_rtp_stream.xml modules/orange_avoider.xml modules/cv_detect_color_object.xml modules/video_capture.xml modules/ins_extended.xml modules/ahrs_int_cmpl_quat.xml modules/stabilization_indi_simple.xml modules/nav_basic_rotorcraft.xml modules/guidance_rotorcraft.xml modules/gps.xml modules/imu_common.xml"
    gui_color="white"
    release="593ed974ecf1a78f2eb2b0168a6fa0c93fad8259"
   />

--- a/sw/airborne/modules/computer_vision/opencv_example.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_example.cpp
@@ -34,24 +34,18 @@ using namespace std;
 using namespace cv;
 #include "opencv_image_functions.h"
 
-#include <cstdio>
 
 int opencv_example(char *img, int width, int height)
 {
   // Create a new image, using the original bebop image.
-  printf("Create image...\n");
-  printf("height = %d, width = %d\n", height, width);
   Mat M(height, width, CV_8UC2, img);
   Mat image;
   // If you want a color image, uncomment this line
-  printf("cvtColor...\n");
   cvtColor(M, image, CV_YUV2BGR_Y422);
-  printf("ok\n");
   // For a grayscale image, use this one
 //  cvtColor(M, image, CV_YUV2GRAY_Y422);
 
   // Blur it, because we can
-  printf("blur...\n");
   blur(image, image, Size(5, 5));
 
   // Canny edges, only works with grayscale image
@@ -60,9 +54,7 @@ int opencv_example(char *img, int width, int height)
 
   // Convert back to YUV422, and put it in place of the original image
 //  grayscale_opencv_to_yuv422(image, img, width, height);
-  printf("rgb to yuv...\n");
-  colorrgb_opencv_to_yuv422(image, img, width, height);
-  printf("done.\n");
+  colorbgr_opencv_to_yuv422(image, img, width, height);
 
   return 0;
 }

--- a/sw/airborne/modules/computer_vision/opencv_example.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_example.cpp
@@ -40,11 +40,13 @@ int opencv_example(char *img, int width, int height)
 {
   // Create a new image, using the original bebop image.
   printf("Create image...\n");
+  printf("height = %d, width = %d\n", height, width);
   Mat M(height, width, CV_8UC2, img);
   Mat image;
   // If you want a color image, uncomment this line
   printf("cvtColor...\n");
   cvtColor(M, image, CV_YUV2BGR_Y422);
+  printf("ok\n");
   // For a grayscale image, use this one
 //  cvtColor(M, image, CV_YUV2GRAY_Y422);
 

--- a/sw/airborne/modules/computer_vision/opencv_example.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_example.cpp
@@ -34,26 +34,33 @@ using namespace std;
 using namespace cv;
 #include "opencv_image_functions.h"
 
+#include <cstdio>
+
 int opencv_example(char *img, int width, int height)
 {
   // Create a new image, using the original bebop image.
+  printf("Create image...\n");
   Mat M(height, width, CV_8UC2, img);
   Mat image;
   // If you want a color image, uncomment this line
-//   cvtColor(M, image, CV_YUV2BGR_Y422);
+  printf("cvtColor...\n");
+  cvtColor(M, image, CV_YUV2BGR_Y422);
   // For a grayscale image, use this one
-  cvtColor(M, image, CV_YUV2GRAY_Y422);
+//  cvtColor(M, image, CV_YUV2GRAY_Y422);
 
   // Blur it, because we can
-//  blur(image, image, Size(5, 5));
+  printf("blur...\n");
+  blur(image, image, Size(5, 5));
 
   // Canny edges, only works with grayscale image
-  int edgeThresh = 35;
-  Canny(image, image, edgeThresh, edgeThresh * 3);
+//  int edgeThresh = 35;
+//  Canny(image, image, edgeThresh, edgeThresh * 3);
 
   // Convert back to YUV422, and put it in place of the original image
-  grayscale_opencv_to_yuv422(image, img, width, height);
-//  colorrgb_opencv_to_yuv422(image, img, width, height);
+//  grayscale_opencv_to_yuv422(image, img, width, height);
+  printf("rgb to yuv...\n");
+  colorrgb_opencv_to_yuv422(image, img, width, height);
+  printf("done.\n");
 
   return 0;
 }

--- a/sw/airborne/modules/computer_vision/opencv_example.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_example.cpp
@@ -40,21 +40,24 @@ int opencv_example(char *img, int width, int height)
   // Create a new image, using the original bebop image.
   Mat M(height, width, CV_8UC2, img);
   Mat image;
-  // If you want a color image, uncomment this line
-  cvtColor(M, image, CV_YUV2BGR_Y422);
-  // For a grayscale image, use this one
-//  cvtColor(M, image, CV_YUV2GRAY_Y422);
 
+#if OPENCVDEMO_GRAYSCALE
+  //  Grayscale image example
+  cvtColor(M, image, CV_YUV2GRAY_Y422);
+  // Canny edges, only works with grayscale image
+  int edgeThresh = 35;
+  Canny(image, image, edgeThresh, edgeThresh * 3);
+  // Convert back to YUV422, and put it in place of the original image
+  grayscale_opencv_to_yuv422(image, img, width, height);
+#else // OPENCVDEMO_GRAYSCALE
+  // Color image example
+  // Convert the image to an OpenCV Mat
+  cvtColor(M, image, CV_YUV2BGR_Y422);
   // Blur it, because we can
   blur(image, image, Size(5, 5));
-
-  // Canny edges, only works with grayscale image
-//  int edgeThresh = 35;
-//  Canny(image, image, edgeThresh, edgeThresh * 3);
-
-  // Convert back to YUV422, and put it in place of the original image
-//  grayscale_opencv_to_yuv422(image, img, width, height);
+  // Convert back to YUV422 and put it in place of the original image
   colorbgr_opencv_to_yuv422(image, img, width, height);
+#endif // OPENCVDEMO_GRAYSCALE
 
   return 0;
 }

--- a/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
@@ -36,32 +36,23 @@ using namespace cv;
 
 void coloryuv_opencv_to_yuv422(Mat image, char *img, int width, int height)
 {
+  // Note: OpenCV3.2.0 stores images in a YVU color order(!)
   CV_Assert(image.depth() == CV_8U);
   CV_Assert(image.channels() == 3);
 
   int nRows = image.rows;
   int nCols = image.cols;
 
-  // If the image is one block in memory we can iterate over it all at once!
-  if (image.isContinuous()) {
-    nCols *= nRows;
-    nRows = 1;
-  }
-
-  // Iterate over the image, setting only the Y value
-  // and setting U and V to 127
-  int i, j;
-  uchar *p;
-  int index_img = 0;
-  for (i = 0; i < nRows; ++i) {
-    p = image.ptr<uchar>(i);
-    for (j = 0; j < nCols; j += 6) {
-      img[index_img++] = p[j + 1]; //U
-      img[index_img++] = p[j];//Y
-      img[index_img++] = p[j + 2]; //V
-      img[index_img++] = p[j + 3]; //Y
-
-
+  int byte_index = 0;
+  for(int r = 0; r < nRows; ++r) {
+    for(int c = 0; c < nCols; ++c) {
+      Vec3b yvu = image.at<Vec3b>(r, c);
+      if((byte_index % 4) == 2) {
+        img[byte_index++] = yvu.val[1]; // U
+      } else {
+        img[byte_index++] = yvu.val[2]; // V
+      }
+      img[byte_index++] = yvu.val[0]; // Y
     }
   }
 }

--- a/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
@@ -34,11 +34,29 @@ using namespace std;
 #include <opencv2/imgproc/imgproc.hpp>
 using namespace cv;
 
+#include <cstdio>
+
+static void find_yuv_order(void) {
+  // Some versions of OpenCV incorrectly swap RGB and/or YUV channels during
+  // conversion. This function tests
+  // https://github.com/opencv/opencv/pull/7481
+  // https://github.com/opencv/opencv/issues/4946
+
+  // While testing for the course, it seems that OpenCV on the Bebop behaves
+  // correctly.
+  Mat test_bgr(1, 1, CV_8UC3);
+  Mat test_yuv;
+  test_bgr.at<Vec3b>(0, 0) = Vec3b(255, 0, 0); // Blue: YUV 29, 239, 103
+  cvtColor(test_bgr, test_yuv, COLOR_BGR2YUV);
+  Vec3b yuv = test_yuv.at<Vec3b>(0, 0);
+  printf("Y = %d, U = %d, V = %d\n", yuv.val[0], yuv.val[1], yuv.val[2]);
+}
+
 void coloryuv_opencv_to_yuv422(Mat image, char *img, int width, int height)
 {
-  // Note: OpenCV3.2.0 stores images in a YVU color order(!)
   CV_Assert(image.depth() == CV_8U);
   CV_Assert(image.channels() == 3);
+  find_yuv_order();
 
   int nRows = image.rows;
   int nCols = image.cols;

--- a/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
@@ -34,29 +34,10 @@ using namespace std;
 #include <opencv2/imgproc/imgproc.hpp>
 using namespace cv;
 
-#include <cstdio>
-
-static void find_yuv_order(void) {
-  // Some versions of OpenCV incorrectly swap RGB and/or YUV channels during
-  // conversion. This function tests
-  // https://github.com/opencv/opencv/pull/7481
-  // https://github.com/opencv/opencv/issues/4946
-
-  // While testing for the course, it seems that OpenCV on the Bebop behaves
-  // correctly.
-  Mat test_bgr(1, 1, CV_8UC3);
-  Mat test_yuv;
-  test_bgr.at<Vec3b>(0, 0) = Vec3b(255, 0, 0); // Blue: YUV 29, 239, 103
-  cvtColor(test_bgr, test_yuv, COLOR_BGR2YUV);
-  Vec3b yuv = test_yuv.at<Vec3b>(0, 0);
-  printf("Y = %d, U = %d, V = %d\n", yuv.val[0], yuv.val[1], yuv.val[2]);
-}
-
 void coloryuv_opencv_to_yuv422(Mat image, char *img, int width, int height)
 {
   CV_Assert(image.depth() == CV_8U);
   CV_Assert(image.channels() == 3);
-  find_yuv_order();
 
   int nRows = image.rows;
   int nCols = image.cols;
@@ -75,7 +56,7 @@ void coloryuv_opencv_to_yuv422(Mat image, char *img, int width, int height)
   }
 }
 
-void colorrgb_opencv_to_yuv422(Mat image, char *img, int width, int height)
+void colorbgr_opencv_to_yuv422(Mat image, char *img, int width, int height)
 {
   // Convert to YUV color space
   cvtColor(image, image, COLOR_BGR2YUV);

--- a/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
+++ b/sw/airborne/modules/computer_vision/opencv_image_functions.cpp
@@ -65,7 +65,7 @@ void coloryuv_opencv_to_yuv422(Mat image, char *img, int width, int height)
   for(int r = 0; r < nRows; ++r) {
     for(int c = 0; c < nCols; ++c) {
       Vec3b yvu = image.at<Vec3b>(r, c);
-      if((byte_index % 4) == 2) {
+      if((byte_index % 4) == 0) {
         img[byte_index++] = yvu.val[1]; // U
       } else {
         img[byte_index++] = yvu.val[2]; // V

--- a/sw/airborne/modules/computer_vision/opencv_image_functions.h
+++ b/sw/airborne/modules/computer_vision/opencv_image_functions.h
@@ -36,7 +36,7 @@
  * Note that the rgb function first converts to YUV, and then to YUV422 making
  * this function slower than coloryuv_opencv_to_yuv422.
  */
-void colorrgb_opencv_to_yuv422(cv::Mat image, char *img, int width, int height);
+void colorbgr_opencv_to_yuv422(cv::Mat image, char *img, int width, int height);
 
 /**
  * Converts cv::Mat with three channels YUV to a YUV422 image.


### PR DESCRIPTION
With this fix, the opencv example module will link the OpenCV lib from the bebop_opencv submodule rather than the locally installed one. This prevents inconsistent behavior between the real drone and the simulator; previously a bug in OpenCV caused U and V channels to be swapped depending on the installed version. The Bebop and sim now both use OpenCV 3.4.5.

Please squash before merging as the intermediate commits may not compile or cause segfaults.