### PR TITLE
Made find_object_centroid documentation more comprehensive

### DIFF
--- a/sw/airborne/modules/computer_vision/cv_detect_color_object.c
+++ b/sw/airborne/modules/computer_vision/cv_detect_color_object.c
@@ -190,11 +190,21 @@ void color_object_detector_init(void)
 
 /*
  * find_object_centroid
- * @param img - input image to process
+ *
+ * Finds the centroid of pixels in an image within filter bounds.
+ * Also returns the amount of pixels that satisfy these filter bounds.
+ *
+ * @param img - input image to process formatted as YUV422.
  * @param p_xc - x coordinate of the centroid of color object
  * @param p_yc - y coordinate of the centroid of color object
+ * @param lum_min - minimum y value for the filter in YCbCr colorspace
+ * @param lum_max - maximum y value for the filter in YCbCr colorspace
+ * @param cb_min - minimum cb value for the filter in YCbCr colorspace
+ * @param cb_max - maximum cb value for the filter in YCbCr colorspace
+ * @param cr_min - minimum cr value for the filter in YCbCr colorspace
+ * @param cr_max - maximum cr value for the filter in YCbCr colorspace
  * @param draw - whether or not to draw on image
- * @return number of pixels found
+ * @return number of pixels of image within the filter bounds.
  */
 uint32_t find_object_centroid(struct image_t *img, int32_t* p_xc, int32_t* p_yc, bool draw,
                               uint8_t lum_min, uint8_t lum_max,


### PR DESCRIPTION
Especially since this is not part of the paparazzi main code, I think it is a valuable addition to make the documentation of this function more comprehensive. It is one of the first functions one comes across when doing the mavlab course, and the although the function does what it says, it's use in orange_avoider_guided is different from what the function name would suggest (it only uses the count instead of using the actual centroid). This can be confusing to new programmers in C++ and I hope these extra lines of documentation might decrease the level of confusion a bit and make for a more gentle start to C++. 

I do understand that if doing this extensive documentation for all the functions, the documentation might become too long, however; for a function that is very often read by new students, I think it is worth the few extra lines of code.