### PR TITLE
Changed default joystick in control panel to SM600

### DIFF
--- a/conf/userconf/tudelft/course2019_control_panel.xml
+++ b/conf/userconf/tudelft/course2019_control_panel.xml
@@ -23,7 +23,7 @@
     <program name="Simulator" command="sw/simulator/pprzsim-launch"/>
     <program name="Joystick" command="sw/ground_segment/joystick/input2ivy">
       <arg flag="-ac" constant="@AIRCRAFT"/>
-      <arg flag="hobbyking.xml"/>
+      <arg flag="sm600.xml"/>
     </program>
     <program name="Environment Simulator" command="sw/simulator/gaia"/>
     <program name="NatNet" command="sw/ground_segment/misc/natnet2ivy"/>
@@ -76,7 +76,7 @@
       </program>
       <program name="Joystick" command="sw/ground_segment/joystick/input2ivy">
         <arg flag="-ac" constant="@AIRCRAFT"/>
-        <arg flag="hobbyking.xml"/>
+        <arg flag="sm600.xml"/>
         <arg flag="-d 0"/>
       </program>
       <program name="Gazebo"/>
@@ -91,7 +91,7 @@
       </program>
       <program name="Joystick" command="sw/ground_segment/joystick/input2ivy">
         <arg flag="-ac" constant="@AIRCRAFT"/>
-        <arg flag="hobbyking.xml"/>
+        <arg flag="sm600.xml"/>
         <arg flag="-d 0"/>
       </program>
       <program name="NatNet" command="sw/ground_segment/misc/natnet2ivy">


### PR DESCRIPTION
The control panel the students are instructed to use now uses the sm600.xml by default instead of the hobbyking.xml