### PR TITLE
Added configs for ps4 gamepads, fixed typos

### DIFF
--- a/conf/joystick/ps4_gamepad.xml
+++ b/conf/joystick/ps4_gamepad.xml
@@ -1,0 +1,104 @@
+<!-- PlayStation 4 gamepad
+
+ It has 6 axes:
+  axis 0: LeftStickHorizontal
+  axis 1: LeftStickVertical
+  axis 2: L2 (left trigger). Also triggers button 6
+  axis 3: RightStickHorizontal
+  axis 4: RightStickVertical
+  axis 5: R2 (right trigger). Also triggers button 7
+
+ It has 13 buttons.
+  b0  - X (blue)
+  b1  - Circle (red)
+  b2  - Triangle (green)
+  b3  - Square (pink)
+  b4  - L1 (left shoulder button)
+  b5  - R1 (right shoulder button)
+  b6  - L2 (left trigger). Also triggers axis 2
+  b7  - R2 (right trigger). Also triggers axis 5
+  b8  - Share (left of touchscreen)
+  b9  - Options (right of touchscreen)
+  b10 - PS (below touchscreen)
+  b11 - L3 (press left stick)
+  b12 - R3 (press right stick)
+
+ and the DPad as a hat
+ You can use the Hat<Position>(<hat_name>) function to trigger events,
+ where <Position> is one of
+ Centered/Up/Right/Down/Left/RightUp/RightDown/LeftUp/LeftDown
+ so e.g. HatDown(dpad)
+
+-->
+
+<joystick>
+  <input>
+    <axis index="0" name="LeftStickHorizontal"/>
+    <axis index="1" name="LeftStickVertical"/>
+    <axis index="2" name="L2" trim="127"/>
+    <axis index="3" name="RightStickHorizontal"/>
+    <axis index="4" name="RightStickVertical"/>
+    <axis index="5" name="R2" trim="127"/>
+    <button index="0" name="X"/>
+    <button index="1" name="Circle"/>
+    <button index="2" name="Triangle"/>
+    <button index="3" name="Square"/>
+    <button index="4" name="L1"/>
+    <button index="5" name="R1"/>
+    <button index="6" name="L2"/>
+    <button index="7" name="R2"/>
+    <button index="8" name="Share"/>
+    <button index="9" name="Options"/>
+    <button index="10" name="PS"/>
+    <button index="11" name="L3"/>
+    <button index="12" name="R3"/>
+    <hat index="0" name="dpad"/>
+  </input>
+
+  <variables>
+    <!-- manual by default and when pressing X, AUTO1 on Square, AUTO2 on Triangle -->
+    <var name="mode" default="0"/>
+    <set var="mode" value="0" on_event="X"/>
+    <set var="mode" value="1" on_event="Square"/>
+    <set var="mode" value="2" on_event="Triangle"/>
+  </variables>
+
+  <messages period="0.05">
+
+    <message class="datalink" name="RC_4CH" send_always="true">
+      <field name="mode" value="mode"/>
+      <field name="throttle" value="Fit(-LeftStickVertical,-127,127,0,127)"/>
+      <field name="roll" value="RightStickHorizontal"/>
+      <field name="pitch" value="RightStickVertical"/>
+      <field name="yaw" value="LeftStickHorizontal"/>
+    </message>
+
+    <!-- go to "Start Engine" block if in AUTO2 and pressing Options button -->
+    <message class="ground" name="JUMP_TO_BLOCK" on_event="(mode > 1) && Options">
+      <field name="block_id" value="IndexOfBlock('Start Engine')"/>
+    </message>
+
+    <!-- go to "Takeoff" block if in AUTO2 and pressing up on dpad -->
+    <message class="ground" name="JUMP_TO_BLOCK" on_event="(mode > 1) && HatUp(dpad)">
+      <field name="block_id" value="IndexOfBlock('Takeoff')"/>
+    </message>
+
+    <!-- go to "land here" block if in AUTO2 and pressing down on dpad -->
+    <message class="ground" name="JUMP_TO_BLOCK" on_event="(mode > 1) && HatDown(dpad)">
+      <field name="block_id" value="IndexOfBlock('land here')"/>
+    </message>
+
+    <!-- resurrect throttle if throttle is 0 and R1 button is pressed -->
+    <message class="ground" name="DL_SETTING" on_event="(LeftStickVertical > 120) && R1">
+      <field name="index" value="IndexOfSetting('autopilot.kill_throttle')"/>
+      <field name="value" value="0"/>
+    </message>
+
+    <!-- kill throttle on L1 button -->
+    <message class="ground" name="DL_SETTING" on_event="L1">
+      <field name="index" value="IndexOfSetting('autopilot.kill_throttle')"/>
+      <field name="value" value="1"/>
+    </message>
+
+  </messages>
+</joystick>

--- a/conf/joystick/ps4_gamepad_yawontriggers.xml
+++ b/conf/joystick/ps4_gamepad_yawontriggers.xml
@@ -1,0 +1,104 @@
+<!-- PlayStation 4 gamepad
+
+ It has 6 axes:
+  axis 0: LeftStickHorizontal
+  axis 1: LeftStickVertical
+  axis 2: L2 (left trigger). Also triggers button 6
+  axis 3: RightStickHorizontal
+  axis 4: RightStickVertical
+  axis 5: R2 (right trigger). Also triggers button 7
+
+ It has 13 buttons.
+  b0  - X (blue)
+  b1  - Circle (red)
+  b2  - Triangle (green)
+  b3  - Square (pink)
+  b4  - L1 (left shoulder button)
+  b5  - R1 (right shoulder button)
+  b6  - L2 (left trigger). Also triggers axis 2
+  b7  - R2 (right trigger). Also triggers axis 5
+  b8  - Share (left of touchscreen)
+  b9  - Options (right of touchscreen)
+  b10 - PS (below touchscreen)
+  b11 - L3 (press left stick)
+  b12 - R3 (press right stick)
+
+ and the DPad as a hat
+ You can use the Hat<Position>(<hat_name>) function to trigger events,
+ where <Position> is one of
+ Centered/Up/Right/Down/Left/RightUp/RightDown/LeftUp/LeftDown
+ so e.g. HatDown(dpad)
+
+-->
+
+<joystick>
+  <input>
+    <axis index="0" name="LeftStickHorizontal"/>
+    <axis index="1" name="LeftStickVertical"/>
+    <axis index="2" name="L2" trim="127"/>
+    <axis index="3" name="RightStickHorizontal"/>
+    <axis index="4" name="RightStickVertical"/>
+    <axis index="5" name="R2" trim="127"/>
+    <button index="0" name="X"/>
+    <button index="1" name="Circle"/>
+    <button index="2" name="Triangle"/>
+    <button index="3" name="Square"/>
+    <button index="4" name="L1"/>
+    <button index="5" name="R1"/>
+    <button index="6" name="L2"/>
+    <button index="7" name="R2"/>
+    <button index="8" name="Share"/>
+    <button index="9" name="Options"/>
+    <button index="10" name="PS"/>
+    <button index="11" name="L3"/>
+    <button index="12" name="R3"/>
+    <hat index="0" name="dpad"/>
+  </input>
+
+  <variables>
+    <!-- manual by default and when pressing X, AUTO1 on Square, AUTO2 on Triangle -->
+    <var name="mode" default="0"/>
+    <set var="mode" value="0" on_event="X"/>
+    <set var="mode" value="1" on_event="Square"/>
+    <set var="mode" value="2" on_event="Triangle"/>
+  </variables>
+
+  <messages period="0.05">
+
+    <message class="datalink" name="RC_4CH" send_always="true">
+      <field name="mode" value="mode"/>
+      <field name="throttle" value="Fit(-LeftStickVertical,-127,127,0,127)"/>
+      <field name="roll" value="RightStickHorizontal"/>
+      <field name="pitch" value="RightStickVertical"/>
+      <field name="yaw" value="Fit(R2-L2,-127,127,-127,127)"/>
+    </message>
+
+    <!-- go to "Start Engine" block if in AUTO2 and pressing Options button -->
+    <message class="ground" name="JUMP_TO_BLOCK" on_event="(mode > 1) && Options">
+      <field name="block_id" value="IndexOfBlock('Start Engine')"/>
+    </message>
+
+    <!-- go to "Takeoff" block if in AUTO2 and pressing up on dpad -->
+    <message class="ground" name="JUMP_TO_BLOCK" on_event="(mode > 1) && HatUp(dpad)">
+      <field name="block_id" value="IndexOfBlock('Takeoff')"/>
+    </message>
+
+    <!-- go to "land here" block if in AUTO2 and pressing down on dpad -->
+    <message class="ground" name="JUMP_TO_BLOCK" on_event="(mode > 1) && HatDown(dpad)">
+      <field name="block_id" value="IndexOfBlock('land here')"/>
+    </message>
+
+    <!-- resurrect throttle if throttle is 0 and R1 button is pressed -->
+    <message class="ground" name="DL_SETTING" on_event="(LeftStickVertical > 120) && R1">
+      <field name="index" value="IndexOfSetting('autopilot.kill_throttle')"/>
+      <field name="value" value="0"/>
+    </message>
+
+    <!-- kill throttle on L1 button -->
+    <message class="ground" name="DL_SETTING" on_event="L1">
+      <field name="index" value="IndexOfSetting('autopilot.kill_throttle')"/>
+      <field name="value" value="1"/>
+    </message>
+
+  </messages>
+</joystick>

--- a/doc/sphinx/source/tutorials/intermediate/create_joystick.rst
+++ b/doc/sphinx/source/tutorials/intermediate/create_joystick.rst
@@ -9,7 +9,7 @@ New joystick configurations can be added in the ``paparazzi/conf/joystick`` dire
 Profile a joystick
 ==================
 
-Test if your joystick is recognized: plug your joystick then run ``dmesg``. The message is different for every device, but the last lines should look like these::
+Test if your joystick is recognized: plug your joystick then run ``dmesg``. The message is different for every device, but the last lines should look like these:
 
     [49174.642275] usb 1-1: new low-speed USB device number 8 using xhci_hcd
     [49174.812307] usb 1-1: New USB device found, idVendor=046d, idProduct=c214, bcdDevice= 2.05
@@ -20,7 +20,7 @@ Test if your joystick is recognized: plug your joystick then run ``dmesg``. The 
     [49174.823608] hid-generic 0003:046D:C214.000B: input,hidraw4: USB HID v1.10 Joystick [Logitech Logitech Attack 3] on usb-0000:00:14.0-1/input0
 
 
-Launch ``./sw/ground_segment/joystick/test_stick``. It will display joystick informations, then print current status::
+Launch ``./sw/ground_segment/joystick/test_stick``. It will display joystick information, then print current status:
 
     Available button: 5 (0x5)
     Available hats: 0 (0x0)
@@ -94,7 +94,7 @@ Create a new file for your joystick in the ``paparazzi/conf/joystick`` directory
 Inputs
 ------
 
-Edit the *input* section according to your info given by *test_stick*. There are 3 kind of inputs :
+Edit the *input* section according to your info given by *test_stick*. There are 3 kind of inputs:
 
 - *axis*: "analog" stick that range from a min to a max value,
 - *hat*: tiny stick or arrows that can have 8 directions (up, down, left, right, up-left, ...),
@@ -102,7 +102,7 @@ Edit the *input* section according to your info given by *test_stick*. There are
 
 *name* and *index* attributes are mandatory for all.
 
-Axis has 4 optionnal attributes:
+Axis has 4 optional attributes:
 
 - *deadband*: input values within the deadband output 0. Range in [0, 127].
 - *exponent*: gives precise control around center values, and greater speed at high values. Range in [0, 1.0]. 0 has no effect, 1.0 has maximum effect.
@@ -124,7 +124,7 @@ The *period* attribute on the *messages* section is the period in seconds at whi
 
 In this section, you define which messages will be sent, the value of each field, and the conditions required to send the message.
 
-The *message* tag has two required attributes: the *name* and *class* of the message, and two optionnal attributes : *send_always* and *on_event*.
+The *message* tag has two required attributes: the *name* and *class* of the message, and two optional attributes : *send_always* and *on_event*.
 
 *send_always* is a boolean that default to *false*. If set to *true*, messages will keep be sent at the *period* rate. If set to *false*, message will be sent only when one of its field change value.
 
@@ -137,12 +137,12 @@ In the message node, all fields must be specified except the *ac_id* field, that
 
 *value* is a "C like" expression made of axis and variables names, operators, and a set of utily functions.
 
-Thoses functions are:
+Those functions are:
 
 - ``Scale(toto, min, max)`` : scale toto from default min/max values [-128, 127] to [*min*, *max*] 
 - ``Fit(x, min_in, max_in, min_out, max_out)`` : scale *x* from *min_in* *max_in* to *min_out*, *max_out*
 - ``Bound(x, min, max)`` : bound x between *min* and *max*
-- ``PprzMode(x)`` : scale input value to [0;1;2]. usefull for RC mode.
+- ``PprzMode(x)`` : scale input value to [0;1;2]. useful for RC mode.
 - ``JoystickID()`` : return the joystick ID.
 - ``IndexOfEnum(NAME)`` : return the index of the enum member *NAME*
 - ``IndexOfSetting('setting_name')`` : return the index of the setting *setting_name*.


### PR DESCRIPTION
Added configs for ps4 gamepads to be used as joysticks, and fixed typos in the josytick creation tutorial