### PR TITLE
FIX gzeof linking error

### DIFF
--- a/conf/modules/cv_opencvdemo.xml
+++ b/conf/modules/cv_opencvdemo.xml
@@ -20,47 +20,13 @@
     <file name="opencv_example.cpp"/>
     <file name="opencv_image_functions.cpp"/>
     <flag name="CXXFLAGS" value="I$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_arm/include"/>
-    
-    <flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_arm/lib"/>
-    <flag name="LDFLAGS" value="lopencv_world"/>
-    <flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_arm/share/OpenCV/3rdparty/lib"/>
-    <flag name="LDFLAGS" value="llibprotobuf"/>
-    <flag name="LDFLAGS" value="llibjpeg-turbo"/>
-    <flag name="LDFLAGS" value="llibpng"/>
-    <flag name="LDFLAGS" value="llibtiff"/>
-    <flag name="LDFLAGS" value="lzlib"/>
-    <flag name="LDFLAGS" value="lquirc"/>
-    <flag name="LDFLAGS" value="ltegra_hal"/>
-    <flag name="LDFLAGS" value="ldl"/>
-    <flag name="LDFLAGS" value="lm"/>
-    <flag name="LDFLAGS" value="lpthread"/>
-    <flag name="LDFLAGS" value="lrt"/>
+    <flag name="LDFLAGS" value="-L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_arm/lib -lopencv_world -L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_arm/share/OpenCV/3rdparty/lib -llibprotobuf -llibjpeg-turbo -llibpng -llibtiff -lzlib -lquirc -ltegra_hal -ldl -lm -lpthread -lrt"/>
   </makefile>
   <makefile target="nps">
     <file name="cv_opencvdemo.c"/>
     <file name="opencv_example.cpp"/>
     <file name="opencv_image_functions.cpp"/>
-    
     <flag name="CXXFLAGS" value="I$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/include"/>
-    
-    <flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_pc/lib"/>
-    <flag name="LDFLAGS" value="lopencv_world"/>
-    <flag name="LDFLAGS" value="L$(PAPARAZZI_HOME)/sw/ext/opencv_bebop/install_pc/share/OpenCV/3rdparty/lib"/>
-    <flag name="LDFLAGS" value="llibprotobuf"/>
-    <flag name="LDFLAGS" value="lquirc"/>
-    <flag name="LDFLAGS" value="L/usr/lib/x86_64-linux-gnu"/>
-    <flag name="LDFLAGS" value="ljpeg"/>
-    <flag name="LDFLAGS" value="lpng"/>
-    <flag name="LDFLAGS" value="ltiff"/>
-    <flag name="LDFLAGS" value="L/usr/lib/x86_64-linux-gnu/hdf5/serial"/>
-    <flag name="LDFLAGS" value="lhdf5"/>
-    <flag name="LDFLAGS" value="lpthread"/>
-    <flag name="LDFLAGS" value="lsz"/>
-    <flag name="LDFLAGS" value="lz"/>
-    <flag name="LDFLAGS" value="ldl"/>
-    <flag name="LDFLAGS" value="lm"/>
-    <flag name="LDFLAGS" value="lfreetype"/>
-    <flag name="LDFLAGS" value="lharfbuzz"/>
-    <flag name="LDFLAGS" value="lrt"/>
+    <flag name="LDFLAGS" value="L$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/lib -lopencv_world -L$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/share/OpenCV/3rdparty/lib -llibprotobuf -llibjpeg-turbo -llibpng -llibtiff -lzlib -lquirc -ldc1394 -L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5 -L/usr/lib/x86_64-linux-gnu -lpthread -lsz -lz -ldl -lm -lfreetype -lharfbuzz -lrt"/>
   </makefile>
 </module>

--- a/conf/modules/cv_opencvdemo.xml
+++ b/conf/modules/cv_opencvdemo.xml
@@ -27,6 +27,6 @@
     <file name="opencv_example.cpp"/>
     <file name="opencv_image_functions.cpp"/>
     <flag name="CXXFLAGS" value="I$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/include"/>
-    <flag name="LDFLAGS" value="L$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/lib -lopencv_world -L$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/share/OpenCV/3rdparty/lib -llibprotobuf -llibjpeg-turbo -llibpng -llibtiff -lzlib -lquirc -ldc1394 -L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5 -L/usr/lib/x86_64-linux-gnu -lpthread -lsz -lz -ldl -lm -lfreetype -lharfbuzz -lrt"/>
+    <flag name="LDFLAGS" value="L$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/lib -lopencv_world -L$(PAPARAZZI_SRC)/sw/ext/opencv_bebop/install_pc/share/OpenCV/3rdparty/lib -llibprotobuf -lquirc -L/usr/lib/x86_64-linux-gnu -ljpeg -lpng -ltiff -ldc1394 -L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5 -lpthread -lsz -lz -ldl -lm -lfreetype -lharfbuzz -lrt"/>
   </makefile>
 </module>


### PR DESCRIPTION
Fix linking error. Apparently the current version of paparazzi reverses the order of the LDFLAGS (order-dependent). This fix puts all flags in a single line.