### PR TITLE
[Camera] Vision runs faster is unnecessary frames are not grabbed.

### DIFF
--- a/conf/airframes/tudelft/bebop_course_orangeavoid.xml
+++ b/conf/airframes/tudelft/bebop_course_orangeavoid.xml
@@ -9,6 +9,7 @@
     <target name="ap" board="bebop">
       <define name="VIDEO_CAPTURE_PATH" value="/data/ftp/internal_000/images"/>
       <define name="FILE_LOGGER_PATH" value="/data/ftp/internal_000/log"/>
+      <define name="MT9V117_TARGET_FPS" value="20"/>
       
       <!-- Detect orange -->
       <define name="COLOR_OBJECT_DETECTOR_LUM_MIN1" value="30"/>

--- a/conf/airframes/tudelft/bebop_course_orangeavoid_guided.xml
+++ b/conf/airframes/tudelft/bebop_course_orangeavoid_guided.xml
@@ -8,6 +8,7 @@
     <target name="ap" board="bebop">
       <define name="VIDEO_CAPTURE_PATH" value="/data/ftp/internal_000/images"/>
       <define name="FILE_LOGGER_PATH" value="/data/ftp/internal_000/log"/>
+      <define name="MT9V117_TARGET_FPS" value="20"/>
       
       <!-- Detect orange -->
       <define name="COLOR_OBJECT_DETECTOR_LUM_MIN1" value="30"/>

--- a/conf/airframes/tudelft/bebop_mav_course_exercise.xml
+++ b/conf/airframes/tudelft/bebop_mav_course_exercise.xml
@@ -8,6 +8,7 @@
     <target name="ap" board="bebop">
       <define name="VIDEO_CAPTURE_PATH" value="/data/ftp/internal_000/images"/>
       <define name="FILE_LOGGER_PATH" value="/data/ftp/internal_000/log"/>
+      <define name="MT9V117_TARGET_FPS" value="20"/>
       
       <!-- Detect orange -->
       <define name="COLOR_OBJECT_DETECTOR_LUM_MIN1" value="40"/>


### PR DESCRIPTION
Framerate is much more consistent when not too many frames are grabbed.
Without settings, the framerate is 90Hz on the bebop1 front cam. This leads to loop times of sometimes 8Hz with the color filter.
Setting the framerate to 20Hz gives a consistent 18Hz of the color filter.