### PR TITLE
Fix gpu acceleration on newer Intel GPUs in container

### DIFF
--- a/docker/gazebo-classic/Dockerfile
+++ b/docker/gazebo-classic/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     # Paparazzi PPA
     && add-apt-repository -y ppa:paparazzi-uav/ppa \
-    # kisak-mesa: Mesa 24.x backport — required for Intel Arc (Meteor Lake) iris driver
-    && add-apt-repository -y ppa:kisak/kisak-mesa \
+    # kisak/turtle: Mesa 25.x backport — required for Intel Arc (Meteor Lake) xe driver
+    && add-apt-repository -y ppa:kisak/turtle \
     # OSRF: Gazebo Classic 11
     && curl -sSL https://packages.osrfoundation.org/gazebo.gpg \
          -o /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \

--- a/docker/gazebo-classic/run_gazebo_sim.sh
+++ b/docker/gazebo-classic/run_gazebo_sim.sh
@@ -47,7 +47,6 @@ X_OPTS=(
     --env="DISPLAY=$DISPLAY"
     --env="XDG_SESSION_TYPE=x11"
     --env="XDG_RUNTIME_DIR=/tmp/runtime-pprz"
-    --env="LIBGL_DRI3_DISABLE=1"
 )
 
 # ── GPU Acceleration ─────────────────────────────────────────────────
@@ -60,7 +59,7 @@ if [ "$GPU_TYPE" = "nvidia" ]; then
     GPU_OPTS+=(--gpus all --env NVIDIA_DRIVER_CAPABILITIES=all)
 elif [ -d /dev/dri ]; then
     echo "[GPU] Using Mesa/Intel/AMD (DRI)"
-    GPU_OPTS+=(--device=/dev/dri/card0 --device=/dev/dri/renderD128)
+    GPU_OPTS+=(--device=/dev/dri)
     RENDER_GID=$(getent group render 2>/dev/null | cut -d: -f3)
     VIDEO_GID=$(getent group video  2>/dev/null | cut -d: -f3)
     [ -n "$RENDER_GID" ] && GPU_OPTS+=(--group-add="$RENDER_GID") && echo "[GPU] Added render group (GID $RENDER_GID)"


### PR DESCRIPTION
The provided container ```gazebo-classic``` did not properly support newer intel GPUs, so I changed the following things to make OpenGL use the GPU:
- The kisak-mesa fresh PPA does not provide a new enough MESA driver newer intel GPUs for ubuntu22, the kisak-mesa stable has to be used instead. 
- The ```LIBGL_DRI3_DISABLE=1``` also blocked GPU rendering. 
- Incorrect devices were passed through to the container.