### PR TITLE
Integrated multi-color ROI filtering with airframe configurations

### DIFF
--- a/conf/airframes/tudelft/bebop_course_orangeavoid.xml
+++ b/conf/airframes/tudelft/bebop_course_orangeavoid.xml
@@ -12,12 +12,37 @@
       <define name="MT9V117_TARGET_FPS" value="20"/>
       
       <!-- Detect orange -->
-      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN1" value="30"/>
-      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX1" value="190"/>
-      <define name="COLOR_OBJECT_DETECTOR_CB_MIN1" value="70"/>
-      <define name="COLOR_OBJECT_DETECTOR_CB_MAX1" value="130"/>
-      <define name="COLOR_OBJECT_DETECTOR_CR_MIN1" value="150"/>
-      <define name="COLOR_OBJECT_DETECTOR_CR_MAX1" value="190"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN1" value="60"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX1" value="250"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MIN1" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MAX1" value="120"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MIN1" value="145"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MAX1" value="220"/>
+
+            <!-- Detect green -->
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN2" value="60"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX2" value="220"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MIN2" value="30"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MAX2" value="120"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MIN2" value="120"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MAX2" value="140"/>
+
+      <!-- Detect green upper -->
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN3" value="60"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX3" value="220"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MIN3" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MAX3" value="122"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MIN3" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MAX3" value="145"/>
+
+     <!-- Detect blue -->
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN4" value="60"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX4" value="220"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MIN4" value="180"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MAX4" value="255"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MIN4" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MAX4" value="100"/>
+
       <module name="ahrs" type="int_cmpl_quat">
         <configure name="USE_MAGNETOMETER" value="FALSE"/>
         <define name="AHRS_USE_GPS_HEADING" value="TRUE"/>
@@ -30,17 +55,45 @@
       <define name="LOGGER_FILE_PATH" value="/tmp/paparazzi/log"/>
       
       <!-- Detect orange -->
-      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN1" value="41"/>
-      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX1" value="183"/>
-      <define name="COLOR_OBJECT_DETECTOR_CB_MIN1" value="53"/>
-      <define name="COLOR_OBJECT_DETECTOR_CB_MAX1" value="121"/>
-      <define name="COLOR_OBJECT_DETECTOR_CR_MIN1" value="134"/>
-      <define name="COLOR_OBJECT_DETECTOR_CR_MAX1" value="249"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN1" value="35"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX1" value="220"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MIN1" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MAX1" value="120"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MIN1" value="160"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MAX1" value="220"/>
+
+              <!-- Detect green -->
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN2" value="60"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX2" value="220"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MIN2" value="30"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MAX2" value="120"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MIN2" value="120"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MAX2" value="140"/>
+
+      <!-- Detect green upper -->
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN3" value="30"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX3" value="100"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MIN3" value="100"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MAX3" value="120"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MIN3" value="100"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MAX3" value="125"/>
+      
+      <!-- Detect blue -->
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MIN4" value="60"/>
+      <define name="COLOR_OBJECT_DETECTOR_LUM_MAX4" value="220"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MIN4" value="180"/>
+      <define name="COLOR_OBJECT_DETECTOR_CB_MAX4" value="255"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MIN4" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_CR_MAX4" value="100"/>
+
       <module name="ahrs" type="float_mlkf"> <!-- was int_cmpl_quat  -->
         <configure name="USE_MAGNETOMETER" value="FALSE"/>
         <define name="AHRS_USE_GPS_HEADING" value="TRUE"/>
+
       </module>
     </target>
+
+    
     
     <define name="ARRIVED_AT_WAYPOINT" value="0.3"/><!-- Detect arrival at waypoint when within 0.3m -->
 
@@ -74,9 +127,25 @@
       <define name="COLOR_OBJECT_DETECTOR_CAMERA1" value="front_camera"/>
       <define name="COLOR_OBJECT_DETECTOR_FPS1" value="0"/>
       <define name="COLOR_OBJECT_DETECTOR_DRAW1" value="1"/>
+
+      <define name="COLOR_OBJECT_DETECTOR_CAMERA2" value="front_camera"/>
+      <define name="COLOR_OBJECT_DETECTOR_FPS2" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_DRAW2" value="1"/>
+
+      <!-- Filter 3: green upper rectangle -->
+      <define name="COLOR_OBJECT_DETECTOR_CAMERA3" value="front_camera"/>
+      <define name="COLOR_OBJECT_DETECTOR_FPS3" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_DRAW3" value="1"/>
+
+      <define name="COLOR_OBJECT_DETECTOR_CAMERA4" value="front_camera"/>
+      <define name="COLOR_OBJECT_DETECTOR_FPS4" value="0"/>
+      <define name="COLOR_OBJECT_DETECTOR_DRAW4" value="1"/>
     </module>
     <module name="orange_avoider">
-      <define name="ORANGE_AVOIDER_VISUAL_DETECTION_ID" value="COLOR_OBJECT_DETECTION1_ID"/>
+      <define name="ORANGE_LOWER_VISUAL_DETECTION_ID" value="1"/>
+      <define name="GREEN_LOWER_VISUAL_DETECTION_ID" value="2"/>
+      <define name="GREEN_UPPER_VISUAL_DETECTION_ID" value="30"/>
+      <define name="BLUE_UPPER_VISUAL_DETECTION_ID" value="4"/>
     </module>
     <module name="video_rtp_stream">
       <define name="VIEWVIDEO_CAMERA" value="front_camera"/>
@@ -84,6 +153,7 @@
       <define name="VIEWVIDEO_DOWNSIZE_FACTOR" value="1"/>
       <define name="VIEWVIDEO_QUALITY_FACTOR" value="40"/>
     </module>
+
   </firmware>
 
   <commands>

--- a/conf/modules/cv_detect_color_object.xml
+++ b/conf/modules/cv_detect_color_object.xml
@@ -4,8 +4,8 @@
   <doc>
     <description>Color Object Detector
     Detects an object by a continuous color. Optionally draws on image.
-    
     </description>
+
     <define name="COLOR_OBJECT_DETECTOR_CAMERA1" value="front_camera|bottom_camera" description="Video device to use"/>
     <define name="COLOR_OBJECT_DETECTOR_FPS1" value="0" description="Desired FPS (0: camera rate)"/>
     <define name="COLOR_OBJECT_DETECTOR_LUM_MIN1" value="0" description="Filter 1 min luminance"/>
@@ -18,32 +18,59 @@
 
     <define name="COLOR_OBJECT_DETECTOR_CAMERA2" value="front_camera|bottom_camera" description="Video device to use"/>
     <define name="COLOR_OBJECT_DETECTOR_FPS2" value="0" description="Desired FPS (0: camera rate)"/>
-    <define name="COLOR_OBJECT_DETECTOR_LUM_MIN2" value="0" description="Filter 1 min luminance"/>
+    <define name="COLOR_OBJECT_DETECTOR_LUM_MIN2" value="0" description="Filter 2 min luminance"/>
     <define name="COLOR_OBJECT_DETECTOR_LUM_MAX2" value="0" description="Filter 2 max luminance"/>
     <define name="COLOR_OBJECT_DETECTOR_CB_MIN2" value="0" description="Filter 2 min blue chroma"/>
     <define name="COLOR_OBJECT_DETECTOR_CB_MAX2" value="0" description="Filter 2 max blue chroma"/>
     <define name="COLOR_OBJECT_DETECTOR_CR_MIN2" value="0" description="Filter 2 min red chroma"/>
     <define name="COLOR_OBJECT_DETECTOR_CR_MAX2" value="0" description="Filter 2 max red chroma"/>
     <define name="COLOR_OBJECT_DETECTOR_DRAW2" value="FALSE|TRUE" description="Whether or not to draw on image"/>
+
+    <define name="COLOR_OBJECT_DETECTOR_CAMERA3" value="front_camera|bottom_camera" description="Video device to use"/>
+    <define name="COLOR_OBJECT_DETECTOR_FPS3" value="0" description="Desired FPS (0: camera rate)"/>
+    <define name="COLOR_OBJECT_DETECTOR_LUM_MIN3" value="0" description="Filter 3 min luminance"/>
+    <define name="COLOR_OBJECT_DETECTOR_LUM_MAX3" value="0" description="Filter 3 max luminance"/>
+    <define name="COLOR_OBJECT_DETECTOR_CB_MIN3" value="0" description="Filter 3 min blue chroma"/>
+    <define name="COLOR_OBJECT_DETECTOR_CB_MAX3" value="0" description="Filter 3 max blue chroma"/>
+    <define name="COLOR_OBJECT_DETECTOR_CR_MIN3" value="0" description="Filter 3 min red chroma"/>
+    <define name="COLOR_OBJECT_DETECTOR_CR_MAX3" value="0" description="Filter 3 max red chroma"/>
+    <define name="COLOR_OBJECT_DETECTOR_DRAW3" value="FALSE|TRUE" description="Whether or not to draw on image"/>
   </doc>
 
   <settings>
     <dl_settings>
       <dl_settings name="ColorObjectDetector">
-         <dl_setting var="cod_lum_min1" min="0" step="1" max="255" shortname="y_min1"/>
-         <dl_setting var="cod_lum_max1" min="0" step="1" max="255" shortname="y_max1"/>
-         <dl_setting var="cod_cb_min1"   min="0" step="1" max="255" shortname="u_min1"/>
-         <dl_setting var="cod_cb_max1"   min="0" step="1" max="255" shortname="u_max1"/>
-         <dl_setting var="cod_cr_min1"   min="0" step="1" max="255" shortname="v_min1"/>
-         <dl_setting var="cod_cr_max1"   min="0" step="1" max="255" shortname="v_max1"/>
-         <dl_setting var="cod_draw1"  min="0" step="1" max="1" values="False|True" shortname="draw 1" />
-         <dl_setting var="cod_lum_min2" min="0" step="1" max="255" shortname="y_min2"/>
-         <dl_setting var="cod_lum_max2" min="0" step="1" max="255" shortname="y_max2"/>
-         <dl_setting var="cod_cb_min2"   min="0" step="1" max="255" shortname="u_min2"/>
-         <dl_setting var="cod_cb_max2"   min="0" step="1" max="255" shortname="u_max2"/>
-         <dl_setting var="cod_cr_min2"   min="0" step="1" max="255" shortname="v_min2"/>
-         <dl_setting var="cod_cr_max2"   min="0" step="1" max="255" shortname="v_max2"/>
-         <dl_setting var="cod_draw2"  min="0" step="1" max="1" values="False|True" shortname="draw 2" />
+        <dl_setting var="cod_lum_min1" min="0" step="1" max="255" shortname="y_min1"/>
+        <dl_setting var="cod_lum_max1" min="0" step="1" max="255" shortname="y_max1"/>
+        <dl_setting var="cod_cb_min1"  min="0" step="1" max="255" shortname="u_min1"/>
+        <dl_setting var="cod_cb_max1"  min="0" step="1" max="255" shortname="u_max1"/>
+        <dl_setting var="cod_cr_min1"  min="0" step="1" max="255" shortname="v_min1"/>
+        <dl_setting var="cod_cr_max1"  min="0" step="1" max="255" shortname="v_max1"/>
+        <dl_setting var="cod_draw1"    min="0" step="1" max="1" values="False|True" shortname="draw 1"/>
+
+        <dl_setting var="cod_lum_min2" min="0" step="1" max="255" shortname="y_min2"/>
+        <dl_setting var="cod_lum_max2" min="0" step="1" max="255" shortname="y_max2"/>
+        <dl_setting var="cod_cb_min2"  min="0" step="1" max="255" shortname="u_min2"/>
+        <dl_setting var="cod_cb_max2"  min="0" step="1" max="255" shortname="u_max2"/>
+        <dl_setting var="cod_cr_min2"  min="0" step="1" max="255" shortname="v_min2"/>
+        <dl_setting var="cod_cr_max2"  min="0" step="1" max="255" shortname="v_max2"/>
+        <dl_setting var="cod_draw2"    min="0" step="1" max="1" values="False|True" shortname="draw 2"/>
+
+        <dl_setting var="cod_lum_min3" min="0" step="1" max="255" shortname="y_min3"/>
+        <dl_setting var="cod_lum_max3" min="0" step="1" max="255" shortname="y_max3"/>
+        <dl_setting var="cod_cb_min3"  min="0" step="1" max="255" shortname="u_min3"/>
+        <dl_setting var="cod_cb_max3"  min="0" step="1" max="255" shortname="u_max3"/>
+        <dl_setting var="cod_cr_min3"  min="0" step="1" max="255" shortname="v_min3"/>
+        <dl_setting var="cod_cr_max3"  min="0" step="1" max="255" shortname="v_max3"/>
+        <dl_setting var="cod_draw3"    min="0" step="1" max="1" values="False|True" shortname="draw 3"/>
+
+        <dl_setting var="cod_lum_min4" min="0" step="1" max="255" shortname="y_min4"/>
+        <dl_setting var="cod_lum_max4" min="0" step="1" max="255" shortname="y_max4"/>
+        <dl_setting var="cod_cb_min4"  min="0" step="1" max="255" shortname="u_min4"/>
+        <dl_setting var="cod_cb_max4"  min="0" step="1" max="255" shortname="u_max4"/>
+        <dl_setting var="cod_cr_min4"  min="0" step="1" max="255" shortname="v_min4"/>
+        <dl_setting var="cod_cr_max4"  min="0" step="1" max="255" shortname="v_max4"/>
+        <dl_setting var="cod_draw4"    min="0" step="1" max="1" values="False|True" shortname="draw 4"/>
       </dl_settings>
     </dl_settings>
   </settings>
@@ -62,4 +89,3 @@
     <file name="cv_detect_color_object.c"/>
   </makefile>
 </module>
-

--- a/sw/airborne/modules/computer_vision/cv_detect_color_object.c
+++ b/sw/airborne/modules/computer_vision/cv_detect_color_object.c
@@ -1,31 +1,21 @@
-/*
- * Copyright (C) 2019 Kirk Scheper <kirkscheper@gmail.com>
- *
- * This file is part of Paparazzi.
- *
- * Paparazzi is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2, or (at your option)
- * any later version.
- *
- * Paparazzi is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Paparazzi; see the file COPYING.  If not, write to
- * the Free Software Foundation, 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
- */
-
 /**
- * @file modules/computer_vision/cv_detect_object.h
- * Assumes the object consists of a continuous color and checks
- * if you are over the defined object or not
+ * @file cv_detect_color_object.c
+ * @brief Color-based object detection with ROI filtering.
+ *
+ * This module detects colored objects using YCbCr thresholds and
+ * region-of-interest (ROI) filtering.
+ *
+ * Filters:
+ *  - Filter 1 & 2: lower trapezoid (ground-level detection)
+ *  - Filter 3 & 4: upper rectangle (forward/elevated detection)
+ *
+ * Outputs are sent via ABI messages to other modules (e.g., avoidance).
+ *
+ * Design goals:
+ *  - Real-time performance
+ *  - Reduced noise via ROI restriction
+ *  - Modular multi-filter architecture
  */
-
-// Own header
 #include "modules/computer_vision/cv_detect_color_object.h"
 #include "modules/computer_vision/cv.h"
 #include "modules/core/abi.h"
@@ -34,6 +24,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <math.h>
+#include <string.h>
 #include "pthread.h"
 
 #define PRINT(string,...) fprintf(stderr, "[object_detector->%s()] " string,__FUNCTION__ , ##__VA_ARGS__)
@@ -46,51 +37,127 @@
 static pthread_mutex_t mutex;
 
 #ifndef COLOR_OBJECT_DETECTOR_FPS1
-#define COLOR_OBJECT_DETECTOR_FPS1 0 ///< Default FPS (zero means run at camera fps)
+#define COLOR_OBJECT_DETECTOR_FPS1 0
 #endif
 #ifndef COLOR_OBJECT_DETECTOR_FPS2
-#define COLOR_OBJECT_DETECTOR_FPS2 0 ///< Default FPS (zero means run at camera fps)
+#define COLOR_OBJECT_DETECTOR_FPS2 0
+#endif
+#ifndef COLOR_OBJECT_DETECTOR_FPS3
+#define COLOR_OBJECT_DETECTOR_FPS3 0
+#endif
+#ifndef COLOR_OBJECT_DETECTION3_ID
+#define COLOR_OBJECT_DETECTION3_ID 30
+#endif
+#ifndef COLOR_OBJECT_DETECTION4_ID
+#define COLOR_OBJECT_DETECTION4_ID 4
 #endif
 
-// Filter Settings
-uint8_t cod_lum_min1 = 0;
-uint8_t cod_lum_max1 = 0;
-uint8_t cod_cb_min1 = 0;
-uint8_t cod_cb_max1 = 0;
-uint8_t cod_cr_min1 = 0;
-uint8_t cod_cr_max1 = 0;
-
-uint8_t cod_lum_min2 = 0;
-uint8_t cod_lum_max2 = 0;
-uint8_t cod_cb_min2 = 0;
-uint8_t cod_cb_max2 = 0;
-uint8_t cod_cr_min2 = 0;
-uint8_t cod_cr_max2 = 0;
+/* Filter settings */
+uint8_t cod_lum_min1 = 0, cod_lum_max1 = 0, cod_cb_min1 = 0, cod_cb_max1 = 0, cod_cr_min1 = 0, cod_cr_max1 = 0;
+uint8_t cod_lum_min2 = 0, cod_lum_max2 = 0, cod_cb_min2 = 0, cod_cb_max2 = 0, cod_cr_min2 = 0, cod_cr_max2 = 0;
+uint8_t cod_lum_min3 = 0, cod_lum_max3 = 0, cod_cb_min3 = 0, cod_cb_max3 = 0, cod_cr_min3 = 0, cod_cr_max3 = 0;
+uint8_t cod_lum_min4 = 0, cod_lum_max4 = 0, cod_cb_min4 = 0, cod_cb_max4 = 0, cod_cr_min4 = 0, cod_cr_max4 = 0;
 
 bool cod_draw1 = false;
 bool cod_draw2 = false;
+bool cod_draw3 = false;
+bool cod_draw4 = false;
 
-// define global variables
 struct color_object_t {
   int32_t x_c;
   int32_t y_c;
   uint32_t color_count;
   bool updated;
 };
-struct color_object_t global_filters[2];
 
-// Function
+struct color_object_t global_filters[4];
+
+/* ROI helpers */
+static bool pixel_in_lower_trapezoid(uint16_t x, uint16_t y, uint16_t img_w, uint16_t img_h);
+static bool pixel_on_lower_trapezoid_border(uint16_t x, uint16_t y, uint16_t img_w, uint16_t img_h);
+static bool pixel_in_upper_rectangle(uint16_t x, uint16_t y, uint16_t img_w, uint16_t img_h);
+static bool pixel_on_upper_rectangle_border(uint16_t x, uint16_t y, uint16_t img_w, uint16_t img_h);
+
 uint32_t find_object_centroid(struct image_t *img, int32_t* p_xc, int32_t* p_yc, bool draw,
                               uint8_t lum_min, uint8_t lum_max,
                               uint8_t cb_min, uint8_t cb_max,
-                              uint8_t cr_min, uint8_t cr_max);
+                              uint8_t cr_min, uint8_t cr_max,
+                              uint8_t filter);
 
-/*
- * object_detector
- * @param img - input image to process
- * @param filter - which detection filter to process
- * @return img
- */
+static bool pixel_in_lower_trapezoid(uint16_t x, uint16_t y, uint16_t img_w, uint16_t img_h)
+{
+  int col_end = (int)(0.35f * img_w);
+  int margin_start = 80;
+  int margin_end = (int)(0.25f * img_h);
+
+  if (col_end <= 0) {
+    return false;
+  }
+  if ((int)x > col_end) {
+    return false;
+  }
+
+  float alpha = (float)x / (float)col_end;
+  float margin = (1.0f - alpha) * margin_start + alpha * margin_end;
+
+  int y_min = (int)roundf(margin);
+  int y_max = (int)roundf((float)img_h - margin);
+
+  return ((int)y >= y_min && (int)y <= y_max);
+}
+
+static bool pixel_on_lower_trapezoid_border(uint16_t x, uint16_t y, uint16_t img_w, uint16_t img_h)
+{
+  int col_end = (int)(0.35f * img_w);
+  int margin_start = 80;
+  int margin_end = (int)(0.25f * img_h);
+
+  if (col_end <= 0) {
+    return false;
+  }
+  if ((int)x > col_end) {
+    return false;
+  }
+
+  float alpha = (float)x / (float)col_end;
+  float margin = (1.0f - alpha) * margin_start + alpha * margin_end;
+
+  int y_min = (int)roundf(margin);
+  int y_max = (int)roundf((float)img_h - margin);
+
+  if (((int)x == 0 || (int)x == col_end) && ((int)y >= y_min && (int)y <= y_max)) {
+    return true;
+  }
+  if (abs((int)y - y_min) <= 1 || abs((int)y - y_max) <= 1) {
+    return true;
+  }
+  return false;
+}
+
+static bool pixel_in_upper_rectangle(uint16_t x, uint16_t y, uint16_t img_w, uint16_t img_h)
+{
+  int x_min = (int)(0.40f * img_w);
+  int x_max = img_w - 1;
+  int y_min = (int)(0.25f * img_h);
+  int y_max = (int)(0.75f * img_h);
+
+  return ((int)x >= x_min && (int)x <= x_max &&
+          (int)y >= y_min && (int)y <= y_max);
+}
+
+static bool pixel_on_upper_rectangle_border(uint16_t x, uint16_t y, uint16_t img_w, uint16_t img_h)
+{
+  int x_min = (int)(0.40f * img_w);
+  int x_max = img_w - 1;
+  int y_min = (int)(0.25f * img_h);
+  int y_max = (int)(0.75f * img_h);
+
+  bool on_vertical = (((int)x == x_min || (int)x == x_max) && ((int)y >= y_min && (int)y <= y_max));
+  bool on_horizontal = (((int)y == y_min || (int)y == y_max) && ((int)x >= x_min && (int)x <= x_max));
+
+  return on_vertical || on_horizontal;
+}
+
 static struct image_t *object_detector(struct image_t *img, uint8_t filter)
 {
   uint8_t lum_min, lum_max;
@@ -98,42 +165,45 @@ static struct image_t *object_detector(struct image_t *img, uint8_t filter)
   uint8_t cr_min, cr_max;
   bool draw;
 
-  switch (filter){
+  switch (filter) {
     case 1:
-      lum_min = cod_lum_min1;
-      lum_max = cod_lum_max1;
-      cb_min = cod_cb_min1;
-      cb_max = cod_cb_max1;
-      cr_min = cod_cr_min1;
-      cr_max = cod_cr_max1;
+      lum_min = cod_lum_min1; lum_max = cod_lum_max1;
+      cb_min  = cod_cb_min1;  cb_max  = cod_cb_max1;
+      cr_min  = cod_cr_min1;  cr_max  = cod_cr_max1;
       draw = cod_draw1;
       break;
     case 2:
-      lum_min = cod_lum_min2;
-      lum_max = cod_lum_max2;
-      cb_min = cod_cb_min2;
-      cb_max = cod_cb_max2;
-      cr_min = cod_cr_min2;
-      cr_max = cod_cr_max2;
+      lum_min = cod_lum_min2; lum_max = cod_lum_max2;
+      cb_min  = cod_cb_min2;  cb_max  = cod_cb_max2;
+      cr_min  = cod_cr_min2;  cr_max  = cod_cr_max2;
       draw = cod_draw2;
+      break;
+    case 3:
+      lum_min = cod_lum_min3; lum_max = cod_lum_max3;
+      cb_min  = cod_cb_min3;  cb_max  = cod_cb_max3;
+      cr_min  = cod_cr_min3;  cr_max  = cod_cr_max3;
+      draw = cod_draw3;
+      break;
+    case 4:
+      lum_min = cod_lum_min4; lum_max = cod_lum_max4;
+      cb_min  = cod_cb_min4;  cb_max  = cod_cb_max4;
+      cr_min  = cod_cr_min4;  cr_max  = cod_cr_max4;
+      draw = cod_draw4;
       break;
     default:
       return img;
-  };
+  }
 
   int32_t x_c, y_c;
-
-  // Filter and find centroid
-  uint32_t count = find_object_centroid(img, &x_c, &y_c, draw, lum_min, lum_max, cb_min, cb_max, cr_min, cr_max);
-  VERBOSE_PRINT("Color count %d: %u, threshold %u, x_c %d, y_c %d\n", camera, object_count, count_threshold, x_c, y_c);
-  VERBOSE_PRINT("centroid %d: (%d, %d) r: %4.2f a: %4.2f\n", camera, x_c, y_c,
-        hypotf(x_c, y_c) / hypotf(img->w * 0.5, img->h * 0.5), RadOfDeg(atan2f(y_c, x_c)));
+  uint32_t count = find_object_centroid(img, &x_c, &y_c, draw,
+                                        lum_min, lum_max, cb_min, cb_max, cr_min, cr_max,
+                                        filter);
 
   pthread_mutex_lock(&mutex);
-  global_filters[filter-1].color_count = count;
-  global_filters[filter-1].x_c = x_c;
-  global_filters[filter-1].y_c = y_c;
-  global_filters[filter-1].updated = true;
+  global_filters[filter - 1].color_count = count;
+  global_filters[filter - 1].x_c = x_c;
+  global_filters[filter - 1].y_c = y_c;
+  global_filters[filter - 1].updated = true;
   pthread_mutex_unlock(&mutex);
 
   return img;
@@ -151,23 +221,35 @@ struct image_t *object_detector2(struct image_t *img, uint8_t camera_id __attrib
   return object_detector(img, 2);
 }
 
+struct image_t *object_detector3(struct image_t *img, uint8_t camera_id);
+struct image_t *object_detector3(struct image_t *img, uint8_t camera_id __attribute__((unused)))
+{
+  return object_detector(img, 3);
+}
+
+struct image_t *object_detector4(struct image_t *img, uint8_t camera_id);
+struct image_t *object_detector4(struct image_t *img, uint8_t camera_id __attribute__((unused)))
+{
+  return object_detector(img, 4);
+}
+
 void color_object_detector_init(void)
 {
-  memset(global_filters, 0, 2*sizeof(struct color_object_t));
+  memset(global_filters, 0, 4* sizeof(struct color_object_t));
   pthread_mutex_init(&mutex, NULL);
+
 #ifdef COLOR_OBJECT_DETECTOR_CAMERA1
 #ifdef COLOR_OBJECT_DETECTOR_LUM_MIN1
   cod_lum_min1 = COLOR_OBJECT_DETECTOR_LUM_MIN1;
   cod_lum_max1 = COLOR_OBJECT_DETECTOR_LUM_MAX1;
-  cod_cb_min1 = COLOR_OBJECT_DETECTOR_CB_MIN1;
-  cod_cb_max1 = COLOR_OBJECT_DETECTOR_CB_MAX1;
-  cod_cr_min1 = COLOR_OBJECT_DETECTOR_CR_MIN1;
-  cod_cr_max1 = COLOR_OBJECT_DETECTOR_CR_MAX1;
+  cod_cb_min1  = COLOR_OBJECT_DETECTOR_CB_MIN1;
+  cod_cb_max1  = COLOR_OBJECT_DETECTOR_CB_MAX1;
+  cod_cr_min1  = COLOR_OBJECT_DETECTOR_CR_MIN1;
+  cod_cr_max1  = COLOR_OBJECT_DETECTOR_CR_MAX1;
 #endif
 #ifdef COLOR_OBJECT_DETECTOR_DRAW1
   cod_draw1 = COLOR_OBJECT_DETECTOR_DRAW1;
 #endif
-
   cv_add_to_device(&COLOR_OBJECT_DETECTOR_CAMERA1, object_detector1, COLOR_OBJECT_DETECTOR_FPS1, 0);
 #endif
 
@@ -175,77 +257,109 @@ void color_object_detector_init(void)
 #ifdef COLOR_OBJECT_DETECTOR_LUM_MIN2
   cod_lum_min2 = COLOR_OBJECT_DETECTOR_LUM_MIN2;
   cod_lum_max2 = COLOR_OBJECT_DETECTOR_LUM_MAX2;
-  cod_cb_min2 = COLOR_OBJECT_DETECTOR_CB_MIN2;
-  cod_cb_max2 = COLOR_OBJECT_DETECTOR_CB_MAX2;
-  cod_cr_min2 = COLOR_OBJECT_DETECTOR_CR_MIN2;
-  cod_cr_max2 = COLOR_OBJECT_DETECTOR_CR_MAX2;
+  cod_cb_min2  = COLOR_OBJECT_DETECTOR_CB_MIN2;
+  cod_cb_max2  = COLOR_OBJECT_DETECTOR_CB_MAX2;
+  cod_cr_min2  = COLOR_OBJECT_DETECTOR_CR_MIN2;
+  cod_cr_max2  = COLOR_OBJECT_DETECTOR_CR_MAX2;
 #endif
 #ifdef COLOR_OBJECT_DETECTOR_DRAW2
   cod_draw2 = COLOR_OBJECT_DETECTOR_DRAW2;
 #endif
-
   cv_add_to_device(&COLOR_OBJECT_DETECTOR_CAMERA2, object_detector2, COLOR_OBJECT_DETECTOR_FPS2, 1);
+#endif
+
+#ifdef COLOR_OBJECT_DETECTOR_CAMERA3
+#ifdef COLOR_OBJECT_DETECTOR_LUM_MIN3
+  cod_lum_min3 = COLOR_OBJECT_DETECTOR_LUM_MIN3;
+  cod_lum_max3 = COLOR_OBJECT_DETECTOR_LUM_MAX3;
+  cod_cb_min3  = COLOR_OBJECT_DETECTOR_CB_MIN3;
+  cod_cb_max3  = COLOR_OBJECT_DETECTOR_CB_MAX3;
+  cod_cr_min3  = COLOR_OBJECT_DETECTOR_CR_MIN3;
+  cod_cr_max3  = COLOR_OBJECT_DETECTOR_CR_MAX3;
+#endif
+#ifdef COLOR_OBJECT_DETECTOR_DRAW3
+  cod_draw3 = COLOR_OBJECT_DETECTOR_DRAW3;
+#endif
+  cv_add_to_device(&COLOR_OBJECT_DETECTOR_CAMERA3, object_detector3, COLOR_OBJECT_DETECTOR_FPS3, 2);
+#endif
+
+#ifdef COLOR_OBJECT_DETECTOR_CAMERA4
+#ifdef COLOR_OBJECT_DETECTOR_LUM_MIN4
+  cod_lum_min4 = COLOR_OBJECT_DETECTOR_LUM_MIN4;
+  cod_lum_max4 = COLOR_OBJECT_DETECTOR_LUM_MAX4;
+  cod_cb_min4  = COLOR_OBJECT_DETECTOR_CB_MIN4;
+  cod_cb_max4  = COLOR_OBJECT_DETECTOR_CB_MAX4;
+  cod_cr_min4  = COLOR_OBJECT_DETECTOR_CR_MIN4;
+  cod_cr_max4  = COLOR_OBJECT_DETECTOR_CR_MAX4;
+#endif
+#ifdef COLOR_OBJECT_DETECTOR_DRAW4
+  cod_draw4 = COLOR_OBJECT_DETECTOR_DRAW4;
+#endif
+  // This registers the 4th filter function
+  cv_add_to_device(&COLOR_OBJECT_DETECTOR_CAMERA4, object_detector4, COLOR_OBJECT_DETECTOR_FPS4, 3);
 #endif
 }
 
-/*
- * find_object_centroid
- *
- * Finds the centroid of pixels in an image within filter bounds.
- * Also returns the amount of pixels that satisfy these filter bounds.
- *
- * @param img - input image to process formatted as YUV422.
- * @param p_xc - x coordinate of the centroid of color object
- * @param p_yc - y coordinate of the centroid of color object
- * @param lum_min - minimum y value for the filter in YCbCr colorspace
- * @param lum_max - maximum y value for the filter in YCbCr colorspace
- * @param cb_min - minimum cb value for the filter in YCbCr colorspace
- * @param cb_max - maximum cb value for the filter in YCbCr colorspace
- * @param cr_min - minimum cr value for the filter in YCbCr colorspace
- * @param cr_max - maximum cr value for the filter in YCbCr colorspace
- * @param draw - whether or not to draw on image
- * @return number of pixels of image within the filter bounds.
- */
 uint32_t find_object_centroid(struct image_t *img, int32_t* p_xc, int32_t* p_yc, bool draw,
                               uint8_t lum_min, uint8_t lum_max,
                               uint8_t cb_min, uint8_t cb_max,
-                              uint8_t cr_min, uint8_t cr_max)
+                              uint8_t cr_min, uint8_t cr_max,
+                              uint8_t filter)
 {
   uint32_t cnt = 0;
   uint32_t tot_x = 0;
   uint32_t tot_y = 0;
   uint8_t *buffer = img->buf;
 
-  // Go through all the pixels
   for (uint16_t y = 0; y < img->h; y++) {
-    for (uint16_t x = 0; x < img->w; x ++) {
-      // Check if the color is inside the specified values
+    for (uint16_t x = 0; x < img->w; x++) {
+
+      bool inside_roi = true;
+
+      if (filter == 1 || filter == 2) {
+        inside_roi = pixel_in_lower_trapezoid(x, y, img->w, img->h);
+      } else if (filter == 3 || filter == 4) {
+        inside_roi = pixel_in_upper_rectangle(x, y, img->w, img->h);
+      }
+
       uint8_t *yp, *up, *vp;
       if (x % 2 == 0) {
-        // Even x
-        up = &buffer[y * 2 * img->w + 2 * x];      // U
-        yp = &buffer[y * 2 * img->w + 2 * x + 1];  // Y1
-        vp = &buffer[y * 2 * img->w + 2 * x + 2];  // V
-        //yp = &buffer[y * 2 * img->w + 2 * x + 3]; // Y2
+        up = &buffer[y * 2 * img->w + 2 * x];
+        yp = &buffer[y * 2 * img->w + 2 * x + 1];
+        vp = &buffer[y * 2 * img->w + 2 * x + 2];
       } else {
-        // Uneven x
-        up = &buffer[y * 2 * img->w + 2 * x - 2];  // U
-        //yp = &buffer[y * 2 * img->w + 2 * x - 1]; // Y1
-        vp = &buffer[y * 2 * img->w + 2 * x];      // V
-        yp = &buffer[y * 2 * img->w + 2 * x + 1];  // Y2
+        up = &buffer[y * 2 * img->w + 2 * x - 2];
+        vp = &buffer[y * 2 * img->w + 2 * x];
+        yp = &buffer[y * 2 * img->w + 2 * x + 1];
       }
-      if ( (*yp >= lum_min) && (*yp <= lum_max) &&
-           (*up >= cb_min ) && (*up <= cb_max ) &&
-           (*vp >= cr_min ) && (*vp <= cr_max )) {
-        cnt ++;
+
+      if (draw && filter == 1 && pixel_on_lower_trapezoid_border(x, y, img->w, img->h)) {
+        *yp = 255;
+      }
+      if (draw && filter == 2 && pixel_on_lower_trapezoid_border(x, y, img->w, img->h)) {
+        *yp = 255;
+      }
+      if (draw && filter == 3 && pixel_on_upper_rectangle_border(x, y, img->w, img->h)) {
+        *yp = 255;
+      }
+
+      if (!inside_roi) {
+        continue;
+      }
+
+      if ((*yp >= lum_min) && (*yp <= lum_max) &&
+          (*up >= cb_min)  && (*up <= cb_max) &&
+          (*vp >= cr_min)  && (*vp <= cr_max)) {
+        cnt++;
         tot_x += x;
         tot_y += y;
-        if (draw){
-          *yp = 255;  // make pixel brighter in image
+        if (draw) {
+          *yp = 255;
         }
       }
     }
   }
+
   if (cnt > 0) {
     *p_xc = (int32_t)roundf(tot_x / ((float) cnt) - img->w * 0.5f);
     *p_yc = (int32_t)roundf(img->h * 0.5f - tot_y / ((float) cnt));
@@ -253,24 +367,42 @@ uint32_t find_object_centroid(struct image_t *img, int32_t* p_xc, int32_t* p_yc,
     *p_xc = 0;
     *p_yc = 0;
   }
+
   return cnt;
 }
 
 void color_object_detector_periodic(void)
 {
-  static struct color_object_t local_filters[2];
+  static struct color_object_t local_filters[4];
   pthread_mutex_lock(&mutex);
-  memcpy(local_filters, global_filters, 2*sizeof(struct color_object_t));
+  memcpy(local_filters, global_filters, 4 * sizeof(struct color_object_t));
   pthread_mutex_unlock(&mutex);
 
-  if(local_filters[0].updated){
-    AbiSendMsgVISUAL_DETECTION(COLOR_OBJECT_DETECTION1_ID, local_filters[0].x_c, local_filters[0].y_c,
-        0, 0, local_filters[0].color_count, 0);
+  if (local_filters[0].updated) {
+    AbiSendMsgVISUAL_DETECTION(COLOR_OBJECT_DETECTION1_ID,
+                               local_filters[0].x_c, local_filters[0].y_c,
+                               0, 0, local_filters[0].color_count, 0);
     local_filters[0].updated = false;
   }
-  if(local_filters[1].updated){
-    AbiSendMsgVISUAL_DETECTION(COLOR_OBJECT_DETECTION2_ID, local_filters[1].x_c, local_filters[1].y_c,
-        0, 0, local_filters[1].color_count, 1);
+
+  if (local_filters[1].updated) {
+    AbiSendMsgVISUAL_DETECTION(COLOR_OBJECT_DETECTION2_ID,
+                               local_filters[1].x_c, local_filters[1].y_c,
+                               0, 0, local_filters[1].color_count, 1);
     local_filters[1].updated = false;
+  }
+
+  if (local_filters[2].updated) {
+    AbiSendMsgVISUAL_DETECTION(COLOR_OBJECT_DETECTION3_ID,
+                               local_filters[2].x_c, local_filters[2].y_c,
+                               0, 0, local_filters[2].color_count, 2);
+    local_filters[2].updated = false;
+  }
+
+  if (local_filters[3].updated) {
+  AbiSendMsgVISUAL_DETECTION(COLOR_OBJECT_DETECTION4_ID,
+                             local_filters[3].x_c, local_filters[3].y_c,
+                             0, 0, local_filters[3].color_count, 3);
+  local_filters[3].updated = false;
   }
 }

--- a/sw/airborne/modules/computer_vision/cv_detect_color_object.h
+++ b/sw/airborne/modules/computer_vision/cv_detect_color_object.h
@@ -46,8 +46,29 @@ extern uint8_t cod_cb_max2;
 extern uint8_t cod_cr_min2;
 extern uint8_t cod_cr_max2;
 
+/* NEW: filter 3 */
+extern uint8_t cod_lum_min3;
+extern uint8_t cod_lum_max3;
+extern uint8_t cod_cb_min3;
+extern uint8_t cod_cb_max3;
+extern uint8_t cod_cr_min3;
+extern uint8_t cod_cr_max3;
+
 extern bool cod_draw1;
 extern bool cod_draw2;
+
+/* NEW */
+extern bool cod_draw3;
+
+/* NEW: filter 4 (Blue) */
+extern uint8_t cod_lum_min4;
+extern uint8_t cod_lum_max4;
+extern uint8_t cod_cb_min4;
+extern uint8_t cod_cb_max4;
+extern uint8_t cod_cr_min4;
+extern uint8_t cod_cr_max4;
+
+extern bool cod_draw4;
 
 // Module functions
 extern void color_object_detector_init(void);


### PR DESCRIPTION
This update expands the cv_detect_color_object module to make it more robust for complex environments.

Key Changes:

More Filters: The module now supports 4 independent color filters simultaneously (instead of the default). This allows the drone to detect multiple different objects at once (e.g., Orange obstacles, Green floors, and Blue gates).

    Two Geometric ROIs: Added spatial "Region of Interest" (ROI) masking to reduce noise:

        Lower Trapezoid: Focuses on the ground area to track floor markers or near obstacles while ignoring the sky.

        Upper Rectangle: Focuses on the horizon to detect elevated objects like gates or plants.

    ABI Integration: Each filter broadcasts its own detection ID, allowing navigation modules to distinguish between different types of obstacles in real-time.