### PR TITLE
Fix joystick -d device argument passed as single token in course control panel

### DIFF
--- a/conf/userconf/tudelft/course_control_panel.xml
+++ b/conf/userconf/tudelft/course_control_panel.xml
@@ -23,7 +23,7 @@
       <program name="Joystick" command="sw/ground_segment/joystick/input2ivy">
         <arg flag="-ac" constant="@AIRCRAFT"/>
         <arg flag="sm600.xml"/>
-        <arg flag="-d 0"/>
+        <arg flag="-d" constant="0"/>
       </program>
       <program name="Gazebo"/>
       <program name="RtpViewer">
@@ -65,7 +65,7 @@
       <program name="Joystick" command="sw/ground_segment/joystick/input2ivy">
         <arg flag="-ac" constant="@AIRCRAFT"/>
         <arg flag="sm600.xml"/>
-        <arg flag="-d 0"/>
+        <arg flag="-d" constant="0"/>
       </program>
       <!--program name="NatNet3">
         <arg flag="-ac 9999" constant="@AC_ID"/>


### PR DESCRIPTION
## Problem

In `conf/userconf/tudelft/course_control_panel.xml`, the joystick device flag was written as:

    <arg flag="-d 0"/>

Paparazzi's session launcher passes each `<arg>` as a separate shell argument,
so `-d 0` was received by `input2ivy` as one token instead of two (`-d` and `0`).
This caused the device number to go unrecognized, breaking joystick input in
both the Simulation - Gazebo and Flight UDP sessions.

## Fix

Split into properly separated attributes:

    <arg flag="-d" constant="0"/>

Applied to both sessions in the file.

This fix was made by Group 11